### PR TITLE
Remove early return from applyBindings

### DIFF
--- a/renderkit/renderer/opengl/backend.zig
+++ b/renderkit/renderer/opengl/backend.zig
@@ -508,7 +508,6 @@ pub fn appendBuffer(comptime T: type, buffer: Buffer, data: []const T) u32 {
 var cur_ib_offset: c_int = 0;
 
 pub fn applyBindings(bindings: BufferBindings) void {
-    if (cur_bindings.eq(bindings)) return;
     cur_bindings = bindings;
 
     if (bindings.index_buffer != 0) {


### PR DESCRIPTION
https://github.com/prime31/zig-renderkit/blob/4e730a89f4bd1f9c0b48398861a920972a4fdcc6/renderkit/renderer/opengl/backend.zig#L511
`render_cache.zig` already does caching of OpenGL binding functions, so removing this return shouldn't hurt performance. Caching here is incorrect, since the OpenGL state can be (and is) modified outside of `applyBindings` for example, in `updateImage`:
https://github.com/prime31/zig-renderkit/blob/4e730a89f4bd1f9c0b48398861a920972a4fdcc6/renderkit/renderer/opengl/backend.zig#L267-L273

This causes trivial programs, like (using [zig-gamekit](https://github.com/prime31/zig-gamekit)):
```zig
const gk = @import("gamekit");

pub fn main() !void {
    try gk.run(.{
        .init = init,
        .render = render,
    });
}

fn init() !void {}

fn render() !void {
    gk.gfx.beginPass(.{});
    gk.gfx.draw.text("The text rendering exists", 5, 20, null);
    gk.gfx.endPass();
}
```
to result in missing textures. This is how it looks like:
![Screenshot from 2021-06-01 17-25-02](https://user-images.githubusercontent.com/38918062/120349363-58aac380-c2fe-11eb-9657-e01b7f71dc4b.png)
