### PR TITLE
Fix for dev version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub const ShaderCompileStep = @import("shader_compiler/shader_compiler.zig").Sha
 pub fn getRenderKitPackage(comptime prefix_path: []const u8) Pkg {
     return .{
         .name = "renderkit",
-        .path = .{ .path = prefix_path ++ "renderkit/renderkit.zig" },
+        .source = .{ .path = prefix_path ++ "renderkit/renderkit.zig" },
     };
 }
 

--- a/shader_compiler/shader_compiler.zig
+++ b/shader_compiler/shader_compiler.zig
@@ -279,7 +279,7 @@ pub const ShaderCompileStep = struct {
             return;
         };
 
-        var dir_obj = try std.fs.cwd().openDir(self.shader_out_path[0 .. self.shader_out_path.len - 1], .{ .iterate = true });
+        var dir_obj = try std.fs.cwd().openIterableDir(self.shader_out_path[0 .. self.shader_out_path.len - 1], .{});
         defer dir_obj.close();
         var walker = try dir_obj.walk(self.builder.allocator);
         defer walker.deinit();
@@ -305,7 +305,7 @@ pub const ShaderCompileStep = struct {
 
                 if (uses_default_vs) {
                     // we may have a relative path if the Options were given a relative output path for the shader or package
-                    if (std.fs.path.isAbsolute(entry.path)) try std.fs.deleteFileAbsolute(entry.path) else try dir_obj.deleteFile(entry.path);
+                    if (std.fs.path.isAbsolute(entry.path)) try std.fs.deleteFileAbsolute(entry.path) else try dir_obj.dir.deleteFile(entry.path);
                 }
             }
         }

--- a/shader_compiler/shader_compiler.zig
+++ b/shader_compiler/shader_compiler.zig
@@ -377,8 +377,7 @@ pub const ShaderCompileStep = struct {
         max_output_bytes: usize = 50 * 1024,
         expand_arg0: std.ChildProcess.Arg0Expand = .no_expand,
     }) !std.ChildProcess.ExecResult {
-        const child = try std.ChildProcess.init(args.argv, args.allocator);
-        defer child.deinit();
+        var child = std.ChildProcess.init(args.argv, args.allocator);
 
         child.stdin_behavior = .Ignore;
         // child.stdout_behavior = .Pipe;

--- a/shader_compiler/shader_compiler.zig
+++ b/shader_compiler/shader_compiler.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const path = std.fs.path;
 const Builder = std.build.Builder;
 const Step = std.build.Step;
-const BufMap = std.BufMap;
+const EnvMap = std.process.EnvMap;
 
 const ShdcParser = @import("shdc_parser.zig").ShdcParser;
 const ShaderProgram = @import("shdc_parser.zig").ShaderProgram;
@@ -373,7 +373,7 @@ pub const ShaderCompileStep = struct {
         argv: []const []const u8,
         cwd: ?[]const u8 = null,
         cwd_dir: ?std.fs.Dir = null,
-        env_map: ?*const BufMap = null,
+        env_map: ?*EnvMap = null,
         max_output_bytes: usize = 50 * 1024,
         expand_arg0: std.ChildProcess.Arg0Expand = .no_expand,
     }) !std.ChildProcess.ExecResult {


### PR DESCRIPTION
fix: https://github.com/prime31/zig-gamekit/issues/15

[This change](https://github.com/prime31/zig-gamekit/pull/14) is inadequate.
The `Pkg.path` syntax remained in other files.

These changes are also needed.
* https://github.com/ziglang/zig/commit/262f4c7b3a850594a75ec154db2ba8d5f9f517ab
* https://github.com/ziglang/zig/commit/9e89000ffc92fd881ccb59d2571debe003a2f7b1
* https://github.com/ziglang/zig/commit/a0a2ce92ca129d28e22c63f7bace1672c43776b5

I confirmed it with the following version.

```
zig version
0.10.0-dev.3027+0e26c6149
```