### PR TITLE
RendererDesc: remove disable_vsync

### DIFF
--- a/renderkit/descriptions.zig
+++ b/renderkit/descriptions.zig
@@ -10,7 +10,6 @@ pub const RendererDesc = struct {
     };
 
     gl_loader: ?*const fn ([*c]const u8) callconv(.C) ?*anyopaque = null,
-    disable_vsync: bool = false,
     pool_sizes: PoolSizes = .{},
 };
 


### PR DESCRIPTION
This isn't used by anything in RenderKit since the native Metal renderer was removed.